### PR TITLE
Add more options to the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Night Shift Shell Utility
 Simple shell utility to control the macOS Night Shift feature introduced in 10.12.4.
 
 Usage is `nshift strength` where strength is a value from 0 to 100. A higher value shifts the color temperature of the display to more warm. A value of 0 disables Night Shift altogether.
+
+Additional ways to use it are `nshift on`, `nshift off`, which do the obvious thing–turn NightShift on/off.
+
+There is also `nshift reset`, _TL;DR: It turns NightShift on and off again._ This helps fixing some external displays which are somehow stuck on a warmer color tone after waking a Macbook from sleep, despite actually not working with NightShift in the first place. (Actually, the external display only reacts to NightShift being turned off, but never to being turned on. I don't know, don't ask.)

--- a/nshift/main.m
+++ b/nshift/main.m
@@ -16,10 +16,45 @@
 #import "CBBlueLightClient.h"
 
 int main(int argc, const char * argv[]) {
-    if (argc == 1) { return 0; }
-    float strength = [[NSString stringWithUTF8String:argv[1]] floatValue] / 100;
-    CBBlueLightClient *client = [[CBBlueLightClient alloc] init];
-    if (strength != 0.0) { [client setStrength:strength commit:true]; }
-    [client setEnabled:(strength != 0.0)];
+    if (argc == 1) {
+        return 0;
+    }
+
+    CBBlueLightClient *client = [CBBlueLightClient new];
+
+    NSString *argument = [NSString stringWithUTF8String:argv[1]];
+
+    if ([@[@"--help", @"-h"] containsObject:argument]) {
+        NSArray *usageLines = @[@"Usage: nshift <0-100> to set strength",
+                                @"       nshift on      to turn NightShift on",
+                                @"       nshift off     to turn NightShift off",
+                                @"       nshift reset   to cycle NightShift (turn it off and on) to help with some external displays",
+                                @""];
+
+        printf([usageLines componentsJoinedByString:@"\n"].UTF8String);
+    }
+    if ([argument isEqualToString:@"off"]) {
+        [client setEnabled:NO];
+    }
+    else if ([argument isEqualToString:@"on"]) {
+        [client setEnabled:YES];
+    }
+    else if ([argument isEqualToString:@"reset"]) {
+        [client setEnabled:YES];
+        [client setEnabled:NO];
+    }
+    else {
+        float strength = [[NSString stringWithUTF8String:argv[1]] floatValue] / 100;
+
+        if (strength != 0.0) {
+            [client setStrength:strength commit:true];
+            [client setEnabled:YES];
+        }
+        else {
+            [client setEnabled:NO];
+        }
+    }
+
     return 0;
 }
+


### PR DESCRIPTION
Hi, I felt the need to add some options to the tool to simply turn nightshift off/on without changing the strength.

Also, since the my reason for using the tool in the first place was that I have a little problem with NightShift and an external display that displays warmer tones after waking my MacBook (despite not actually being supported by NightShift anyway) and the only fix for that is to cycle NightShift to "on" and back to "off", I added a "reset" option as well, which does just that. Put it on a keyboard shortcut and am happy again :)